### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -9,7 +9,7 @@ module "application_insights" {
 
   common_tags = var.common_tags
 
-  location - var.appinsights_location
+  location = var.appinsights_location
 }
 
 moved {

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,18 +1,3 @@
-resource "azurerm_application_insights" "appinsights" {
-  name                = join("-", [var.product, var.env])
-  location            = var.appinsights_location
-  resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-
-  lifecycle {
-      ignore_changes = [
-        # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-        # destroys and re-creates this appinsights instance
-        application_type,
-      ]
-    }
-}
-
 module "application_insights" {
   source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
 

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -8,6 +8,8 @@ module "application_insights" {
   resource_group_name = azurerm_resource_group.rg.name
 
   common_tags = var.common_tags
+
+  location - var.appinsights_location
 }
 
 moved {

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -13,6 +13,23 @@ resource "azurerm_application_insights" "appinsights" {
     }
 }
 
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = "${var.product}"
+
+  resource_group_name = azurerm_resource_group.rg.name
+
+  common_tags = var.common_tags
+}
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
+
 # output "appInsightsInstrumentationKey" {
 #   value = "${azurerm_application_insights.appinsights.instrumentation_key}"
 # }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.